### PR TITLE
CLI improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,22 +16,26 @@ $ bundle install
 
 ## Decide what to crawl
 
-Crawlables are read from input files in ./crawlables/ directory. 
+Crawlables are read from input files in ./crawlables/ directory.
 
 For example: ./crawlables/crawl_github.txt contains a hash with the following keys:
 - 'url' => the starting URL to crawl
-- 'ignored_url' => a list of regex for URLs that will be ignored 
+- 'ignored_url' => a list of regex for URLs that will be ignored
 - 'main_divs' => a list of <div> IDs that will be extracted from the HTML of the crawled page
 - 'score_divs' => a list of <div> IDs that will be extracted from the HTML of the page for various scoring reasons
 Note that the lines in the beginning of the file starting with # will be ignored, and the rest will be evaluated into a hash using `eval()`
 
 ## Start crawling!
 
-Two command line arguments are required: 
+Two command line arguments are required:
 - filename: specifies which crawlable from ./crawlables/ directory we want to start crawling
 - limit: the maximum number of crawls before the crawler stops
+
+Optional argument:
+- url: alternative starting URL, which overrides the url in the input file
 
 For example:
 ```
 $ ruby main.rb crawl_github.txt 10
+$ ruby main.rb crawl_github.txt 10 https://github.com/codeGUST-SE/crawler/
 ```

--- a/README.md
+++ b/README.md
@@ -13,3 +13,25 @@ Install the dependencies:
 ```
 $ bundle install
 ```
+
+## Decide what to crawl
+
+Crawlables are read from input files in ./crawlables/ directory. 
+
+For example: ./crawlables/crawl_github.txt contains a hash with the following keys:
+- 'url' => the starting URL to crawl
+- 'ignored_url' => a list of regex for URLs that will be ignored 
+- 'main_divs' => a list of <div> IDs that will be extracted from the HTML of the crawled page
+- 'score_divs' => a list of <div> IDs that will be extracted from the HTML of the page for various scoring reasons
+Note that the lines in the beginning of the file starting with # will be ignored, and the rest will be evaluated into a hash using `eval()`
+
+## Start crawling!
+
+Two command line arguments are required: 
+- filename: specifies which crawlable from ./crawlables/ directory we want to start crawling
+- limit: the maximum number of crawls before the crawler stops
+
+For example:
+```
+$ ruby main.rb crawl_github.txt 10
+```

--- a/crawlable_pages.rb
+++ b/crawlable_pages.rb
@@ -1,27 +1,36 @@
-
 class CrawlablePages
+
+  DIR = 'crawlables/'
+
+  def initialize(filename)
+    @path = DIR + filename
+  end
+
+  def get
+    file_content = ''
+    File.open(@path, 'r') do |f|
+      f.each_line do |line|
+        # ignore lines that start with #
+        if line.start_with? '#'
+          next
+        end
+        file_content += line
+      end
+    end
+    hash = eval(file_content)
+    Crawlable.new(hash['url'], hash['ignored_urls'], hash['main_divs'],
+      hash['score_divs'])
+  end
+
   class Crawlable
     attr_accessor :url, :ignored_urls, :main_divs, :score_divs
 
-    def initialize(url = "", ignored_urls = [], main_divs = [], score_divs = [])
+    def initialize(url = '', ignored_urls = [], main_divs = [], score_divs = [])
       @url = url
       @ignored_urls = ignored_urls
       @main_divs = main_divs
       @score_divs = score_divs
     end
   end
-
-  GITHUB = Crawlable.new(
-    'https://github.com/',
-    [/features/,/business/,/explore/,/marketplace/,/pricing/,/dashboard/,/login(.*)/,/join(.*)/,/features(.*)/,/personal(.*)/,/about(.*)/,/contact(.*)/,/site(.*)/,/blog(.*)/,/opensearch.xml/,/fluidicon.png/,/manifest.json/],
-    ['div#readme','div.blob-wrapper'],
-    ['a.social-count.js-social-count']
-  )
-
-  STACK_OVERFLOW = Crawlable.new(
-    'https://stackoverflow.com/questions',
-    [/questions.ask/,/user(.*)/,/.jobs(.*)/,/tags(.*)/,/help(.*)/,/tour(.*)/,/company(.*)/,/tagged(.*)/,/.tab(.*)/,/election(.*)/,/opensearch.xml/],
-    ['div#question-header a.question-hyperlink','div.postcell','div.answercell'],
-    ['div.vote','div.favoritecount']
-  )
+  
 end

--- a/crawlable_pages.rb
+++ b/crawlable_pages.rb
@@ -2,8 +2,9 @@ class CrawlablePages
 
   DIR = 'crawlables/'
 
-  def initialize(filename)
+  def initialize(filename, alt_url)
     @path = DIR + filename
+    @alt_url = alt_url
   end
 
   def get_crawlable
@@ -17,7 +18,12 @@ class CrawlablePages
         file_content += line
       end
     end
+
     hash = eval(file_content)
+    if !@alt_url.nil?
+      hash['url'] = @alt_url
+    end
+
     Crawlable.new(hash['url'], hash['ignored_urls'], hash['main_divs'],
       hash['score_divs'])
   end

--- a/crawlable_pages.rb
+++ b/crawlable_pages.rb
@@ -6,7 +6,7 @@ class CrawlablePages
     @path = DIR + filename
   end
 
-  def get
+  def get_crawlable
     file_content = ''
     File.open(@path, 'r') do |f|
       f.each_line do |line|
@@ -32,5 +32,5 @@ class CrawlablePages
       @score_divs = score_divs
     end
   end
-  
+
 end

--- a/crawlables/crawl_github.txt
+++ b/crawlables/crawl_github.txt
@@ -1,4 +1,4 @@
-# Crawl all Stack Overflow
+# Crawl all GitHub
 {
   'url' => 'https://github.com/',
   'ignored_urls' => [/features/,/business/,/explore/,/marketplace/,/pricing/,/dashboard/,/login(.*)/,/join(.*)/,/features(.*)/,/personal(.*)/,/about(.*)/,/contact(.*)/,/site(.*)/,/blog(.*)/,/opensearch.xml/,/fluidicon.png/,/manifest.json/],

--- a/crawlables/crawl_github.txt
+++ b/crawlables/crawl_github.txt
@@ -1,0 +1,7 @@
+# Crawl all Stack Overflow
+{
+  'url' => 'https://github.com/',
+  'ignored_urls' => [/features/,/business/,/explore/,/marketplace/,/pricing/,/dashboard/,/login(.*)/,/join(.*)/,/features(.*)/,/personal(.*)/,/about(.*)/,/contact(.*)/,/site(.*)/,/blog(.*)/,/opensearch.xml/,/fluidicon.png/,/manifest.json/],
+  'main_divs' => ['div#readme','div.blob-wrapper'],
+  'score_divs' => ['a.social-count.js-social-count']
+}

--- a/crawlables/crawl_stackoverflow.txt
+++ b/crawlables/crawl_stackoverflow.txt
@@ -1,0 +1,7 @@
+# Crawl all Stack Overflow
+{
+  'url' => 'https://stackoverflow.com/questions',
+  'ignored_urls' => [/questions.ask/,/user(.*)/,/.jobs(.*)/,/tags(.*)/,/help(.*)/,/tour(.*)/,/company(.*)/,/tagged(.*)/,/.tab(.*)/,/election(.*)/,/opensearch.xml/],
+  'main_divs' => ['div#question-header a.question-hyperlink','div.postcell','div.answercell'],
+  'score_divs' => ['div.vote','div.favoritecount']
+}

--- a/crawler.rb
+++ b/crawler.rb
@@ -7,12 +7,13 @@ require 'uri'
 
 =begin
     @param crawlable is the Crawlable object to be crawled
+    @param max_crawls the max number of pages to be crawled
 =end
 class Crawler
-  MAX_CRAWLS = 20   # TODO: Determine the max number of crawls we want
 
-  def initialize(crawlable)
+  def initialize(crawlable, limit)
     @crawlable = crawlable
+    @max_crawls = limit
     @@dataset ||= Google::Cloud::Datastore.new(project_id: "codegust")
   end
 
@@ -45,7 +46,7 @@ class Crawler
         puts crawled_page.url   # DEBUG
 
         # stop crawling after some number of pages
-        if cnt == MAX_CRAWLS
+        if cnt == @max_crawls
           return
         end
 
@@ -64,4 +65,5 @@ class Crawler
     entity.exclude_from_indexes! "page_html", true
     @@dataset.save entity
   end
+  
 end

--- a/main.rb
+++ b/main.rb
@@ -1,4 +1,11 @@
 require_relative 'crawlable_pages'
 require_relative 'crawler'
 
-Crawler.new(CrawlablePages::GITHUB).start_crawling()
+if ARGV.length != 2
+  raise ArgumentError, "Invalid number of arguments"
+end
+
+filename = ARGV[0]
+limit = Integer(ARGV[1])
+
+Crawler.new(CrawlablePages.new(filename).get, limit).start_crawling()

--- a/main.rb
+++ b/main.rb
@@ -1,11 +1,15 @@
 require_relative 'crawlable_pages'
 require_relative 'crawler'
 
-if ARGV.length != 2
+if !ARGV.length.between?(2, 3)
   raise ArgumentError, "Invalid number of arguments"
 end
 
 filename = ARGV[0]
 limit = Integer(ARGV[1])
 
-Crawler.new(CrawlablePages.new(filename).get_crawlable, limit).start_crawling()
+if ARGV.length == 3
+  url = ARGV[2]
+end
+
+Crawler.new(CrawlablePages.new(filename, url).get_crawlable, limit).start_crawling()

--- a/main.rb
+++ b/main.rb
@@ -8,4 +8,4 @@ end
 filename = ARGV[0]
 limit = Integer(ARGV[1])
 
-Crawler.new(CrawlablePages.new(filename).get, limit).start_crawling()
+Crawler.new(CrawlablePages.new(filename).get_crawlable, limit).start_crawling()


### PR DESCRIPTION
Crawlables are read from input files in ./crawlables/ directory.

Two command line arguments are required:
- filename: specifies which crawlable from ./crawlables/ directory we want to start crawling
- limit: the maximum number of crawls before the crawler stops

Optional argument:
- url: alternative starting URL, which overrides the url in the input file