### PR TITLE
Solve the redundant spaces problem once and for all

### DIFF
--- a/crawler.rb
+++ b/crawler.rb
@@ -97,11 +97,7 @@ class Crawler
   end
 
   def transform_text(page)
-    transformed_page = 
-      page.gsub(/\n+/, "\n")
-          .gsub(/\t\t*/, "\t")
-          .gsub(/\s*\n/, "\n")
-      
+    transformed_page = page.gsub(/\s+/, ' ').strip()
     transformed_page
   end
 


### PR DESCRIPTION
Replace all matches of /\s+/ with space as we will not need space/newline/tab etc information during indexing.